### PR TITLE
Fix Cloth class being searched for by mixins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,3 +10,9 @@
 ## 1.1
 - Clicking "proceed" on the feature flag warning screen will automatically exit the world, back to the title screen. A reload is no longer triggered.
 - "Proceed" on the warning screens can no longer be clicked without ticking the checkbox.
+
+## 1.2
+### 1.2.0
+- Integration for Cloth Gamerules screen.
+### 1.2.1
+- Fix Mixin searching for ClotGamerules classes when not installed.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version=0.15.7
 fabric_version=0.87.2+1.19.4
 
 # Mod Properties
-mod_version=1.2.0
+mod_version=1.2.1
 maven_group=tk.estecka.packrulemenus
 archives_base_name=packrule-menus
 

--- a/src/main/java/tk/estecka/packrulemenus/PackRuleMenus.java
+++ b/src/main/java/tk/estecka/packrulemenus/PackRuleMenus.java
@@ -1,9 +1,24 @@
 package tk.estecka.packrulemenus;
 
+import java.util.Optional;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
+import net.minecraft.world.GameRules;
+import tk.estecka.clothgamerules.api.ClothGamerulesScreenFactory;
 
 public class PackRuleMenus
 {
 	static public final Logger LOGGER = LoggerFactory.getLogger("Pack-Rule Menus");
+
+	static public Screen CreateGameruleScreen(Screen parent, GameRules rules, Consumer<Optional<GameRules>> saveConsumer){
+		if (FabricLoader.getInstance().isModLoaded("cloth-gamerules"))
+			return ClothGamerulesScreenFactory.CreateScreen(parent, rules, saveConsumer);
+		else
+			return new EditGameRulesScreen(rules, saveConsumer.andThen( __->MinecraftClient.getInstance().setScreen(parent) ));
+	}
 }

--- a/src/main/java/tk/estecka/packrulemenus/mixin/OptionScreenMixin.java
+++ b/src/main/java/tk/estecka/packrulemenus/mixin/OptionScreenMixin.java
@@ -1,8 +1,6 @@
 package tk.estecka.packrulemenus.mixin;
 
 import java.util.Collection;
-import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -13,13 +11,11 @@ import org.spongepowered.asm.mixin.injection.At.Shift;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.sugar.Local;
 import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.screen.MessageScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
 import net.minecraft.client.gui.screen.option.OptionsScreen;
 import net.minecraft.client.gui.screen.pack.PackScreen;
-import net.minecraft.client.gui.screen.world.EditGameRulesScreen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.GridWidget;
 import net.minecraft.resource.DataConfiguration;
@@ -32,7 +28,6 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.WorldSavePath;
 import net.minecraft.world.GameRules;
-import tk.estecka.clothgamerules.api.ClothGamerulesScreenFactory;
 import tk.estecka.packrulemenus.GenericWarningScreen;
 import tk.estecka.packrulemenus.PackRuleMenus;
 
@@ -58,7 +53,8 @@ extends Screen
 			final GameRules worldRules = server.getOverworld().getGameRules();
 			adder.add(createButton(
 				Text.translatable("selectWorld.gameRules"),
-				() -> CreateGameruleScreen(
+				() -> PackRuleMenus.CreateGameruleScreen(
+					this,
 					worldRules.copy(),
 					optRules -> optRules.ifPresent(r -> worldRules.setAllValues(r, server))
 				)
@@ -75,13 +71,6 @@ extends Screen
 				)
 			));
 		}
-	}
-	
-	private Screen CreateGameruleScreen(GameRules rules, Consumer<Optional<GameRules>> saveConsumer){
-		if (FabricLoader.getInstance().isModLoaded("cloth-gamerules"))
-			return ClothGamerulesScreenFactory.CreateScreen(this, rules, saveConsumer);
-		else
-			return new EditGameRulesScreen(rules, saveConsumer.andThen( __->RevertScreen() ));
 	}
 
 	private void	RevertScreen(){


### PR DESCRIPTION
Moves Cloth-Gamerules related code outside of mixin classes, to prevent it from being scanned when the mod is not installed.